### PR TITLE
Fix Sprocket require_tree argument

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,6 @@
 //= require jquery_ujs
 //= require foundation
 //= require turbolinks
-//= require_tree ./global
+//= require_tree .
 
 $(function(){ $(document).foundation(); });


### PR DESCRIPTION
Regressed the require_tree argument from `./global` to `.` due to runtime errors.
