### PR TITLE
Adds use of spatial index and starring ability for public notes

### DIFF
--- a/app/assets/javascripts/geolocation/App.js
+++ b/app/assets/javascripts/geolocation/App.js
@@ -180,12 +180,19 @@ mapkeep.App.prototype.addMarkerListener = function(marker, noteId) {
     if (this.notes[noteId]) {
       this.formManager.showForm(this.notes[noteId], 0);
     } else {
-      $.getJSON('/notes/' + noteId + '.json', function(data) {
-        this.notes[noteId] = data;
-        this.formManager.showForm(this.notes[noteId], 0);
-      }.bind(this)).error(function() {
-        this.tryAgain();
-      }.bind(this));
+      var self = this;
+      $.ajax({
+        url: '/notes/' + noteId + '.json',
+        type: 'GET',
+        dataType: 'json',
+        success: function(data) {
+          self.notes[noteId] = data;
+          self.formManager.showForm(self.notes[noteId], 0);
+        },
+        error: function() {
+          self.tryAgain();
+        }
+      });
     }
   }.bind(this));
 };

--- a/app/assets/javascripts/geolocation/App.js
+++ b/app/assets/javascripts/geolocation/App.js
@@ -22,6 +22,14 @@ mapkeep.App = function(auth) {
 };
 
 /**
+ * Alert user something went wrong
+ */
+mapkeep.App.prototype.tryAgain = function() {
+  alert('Oops! Something went wrong. ' +
+    'Please reload the page and try again.');
+};
+
+/**
  * Initializes map at input coordinates with user's notes
  * Initializes form helper
  * @param user
@@ -173,9 +181,10 @@ mapkeep.App.prototype.addMarkerListener = function(marker, noteId) {
       this.formManager.showForm(this.notes[noteId], 0);
     } else {
       $.getJSON('/notes/' + noteId + '.json', function(data) {
-        // TODO: error ?
         this.notes[noteId] = data;
         this.formManager.showForm(this.notes[noteId], 0);
+      }.bind(this)).error(function() {
+        this.tryAgain();
       }.bind(this));
     }
   }.bind(this));

--- a/app/assets/javascripts/geolocation/App.js
+++ b/app/assets/javascripts/geolocation/App.js
@@ -44,14 +44,13 @@ mapkeep.App.prototype.init = function(user, notes, albums) {
     var marker = new google.maps.Marker({
       position: new google.maps.LatLng(note.latitude, note.longitude),
       map: this.map,
-      title: note.title,
       draggable: false
     });
     var nonUser = note.user_id != user.id;
     if (nonUser) {
       marker.setIcon('http://www.googlemapsmarkers.com/v1/7777e1/');
     }
-    this.formManager.createNoteView(marker, note, nonUser);
+    // this.formManager.createNoteView(marker, note, nonUser);
   }
 
   this.map.controls[google.maps.ControlPosition.TOP_RIGHT]

--- a/app/assets/javascripts/geolocation/App.js
+++ b/app/assets/javascripts/geolocation/App.js
@@ -176,6 +176,7 @@ mapkeep.App.prototype.addMarkerListener = function(marker, noteId) {
       this.formManager.showForm(this.notes[noteId], 0);
     } else {
       $.getJSON('/notes/' + noteId + '.json', function(data) {
+        // TODO: error ?
         this.notes[noteId] = data;
         this.formManager.showForm(this.notes[noteId], 0);
       }.bind(this));

--- a/app/assets/javascripts/geolocation/App.js
+++ b/app/assets/javascripts/geolocation/App.js
@@ -200,6 +200,8 @@ mapkeep.App.prototype.bounceMarker = function(time) {
  * @param note
  */
 mapkeep.App.prototype.noteCreated = function(note) {
+  this.notes[note.id] = note;
+  this.addMarkerListener(this.curMarker, note.id);
   this.formManager.updateFormAction(note);
   this.formManager.formSubmitted(note);
 };

--- a/app/assets/javascripts/geolocation/App.js
+++ b/app/assets/javascripts/geolocation/App.js
@@ -10,8 +10,6 @@ mapkeep.App = function(auth) {
   this.curWindow = null;
   /** Last clicked marker */
   this.curMarker = null;
-  /** Markers corresponding to note locations */
-  this.markers = {};
   /** The google map object */
   this.map = null;
   /** The user's current location */
@@ -54,7 +52,6 @@ mapkeep.App.prototype.init = function(user, notes, albums) {
       marker.setIcon('http://www.googlemapsmarkers.com/v1/7777e1/');
     }
 
-    this.markers[note.id] = marker;
     this.addMarkerListener(marker, note.id);
   }
 

--- a/app/assets/javascripts/geolocation/App.js
+++ b/app/assets/javascripts/geolocation/App.js
@@ -24,14 +24,14 @@ mapkeep.App = function(auth) {
 /**
  * Initializes map at input coordinates with user's notes
  * Initializes form helper
- * @param location
+ * @param user
  * @param notes
  * @param albums
  */
-mapkeep.App.prototype.init = function(location, notes, albums) {
+mapkeep.App.prototype.init = function(user, notes, albums) {
 
-  if (location.lat && location.lng) {
-    this.userLoc = new google.maps.LatLng(location.lat, location.lng);
+  if (user.location.lat && user.location.lng) {
+    this.userLoc = new google.maps.LatLng(user.location.lat, user.location.lng);
   }
 
   this.formManager.init(albums);
@@ -39,16 +39,15 @@ mapkeep.App.prototype.init = function(location, notes, albums) {
   this.setUpClicks();
 
   // Draw user and public notes on map
-  var allNotes = notes.user_notes.concat(notes.public_notes);
-  for (var i = 0; i < allNotes.length; i++) {
-    var note = allNotes[i];
-    var nonUser = i >= notes.user_notes.length;
+  for (var i = 0; i < notes.length; i++) {
+    var note = notes[i];
     var marker = new google.maps.Marker({
       position: new google.maps.LatLng(note.latitude, note.longitude),
       map: this.map,
       title: note.title,
       draggable: false
     });
+    var nonUser = note.user_id != user.id;
     if (nonUser) {
       marker.setIcon('http://www.googlemapsmarkers.com/v1/7777e1/');
     }

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -64,8 +64,9 @@ mapkeep.FormManager.prototype.init = function(albums) {
   overlay.on('click', '#star', function() {
     var putStar = $(this).html() === '☆';
     $(this).html(putStar ? '★' : '☆');
+    var noteId = $(this).parent().attr('id');
     $.ajax({
-      url: '/notes/' + $(this).data('note_id') + '/stars/' + self.app.user.id,
+      url: '/notes/' + noteId + '/stars/' + self.app.user.id,
       type: putStar ? 'PUT' : 'DELETE',
       success: function(data) {
         // TODO: error ?
@@ -145,8 +146,9 @@ mapkeep.FormManager.prototype.createNoteView =
         .append(this.hiddenInput('_method', note ? 'patch' : 'post'));
     } else if (note) {
       var star = note.starred ? '★' : '☆';
-      var span = $('<span id="star">' + star + '</span>');
-      span.data('note_id', note.id);
+      var span = $('<span/>')
+        .attr('id', note.id)
+        .append($('<span/>').attr('id', 'star').html(star));
       holder.find('#album-div').append(span);
     }
 

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -59,6 +59,11 @@ mapkeep.FormManager.prototype.init = function(albums) {
     overlay.find('input[name=_method]').val('delete');
   });
 
+  // Star button click
+  overlay.on('click', '#star', function() {
+
+  });
+
   // Album button click
   var self = this;
   overlay.on('click', '#album-dropdown a', function() {
@@ -130,6 +135,8 @@ mapkeep.FormManager.prototype.createNoteView =
         .append(this.createRadioGroup(note))
         .append(this.createFormButtons(note ? true : false))
         .append(this.hiddenInput('_method', note ? 'patch' : 'post'));
+    } else {
+      holder.find('.group').append('<span id="star">☆</span>');
     }
 
     if (note) {

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -413,7 +413,7 @@ mapkeep.FormManager.prototype.showForm = function(note, timeout) {
   setTimeout(function() {
     this.app.openInfoWindow(
       this.curForm.find('input[name=note\\[title\\]]').val(),
-      this.app.curMarker // TODO: index marker by note id ?
+      this.app.curMarker
     );
   }.bind(this), timeout);
 

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -62,23 +62,22 @@ mapkeep.FormManager.prototype.init = function(albums) {
   // Star button click
   var self = this;
   overlay.on('click', '#star', function() {
-    var route;
+    var type;
     if ($(this).html() === '★') {
       $(this).html('☆');
-      route = '/notes/delete_star';
+      type = 'DELETE';
     } else {
       $(this).html('★');
-      route = '/notes/add_star';
+      type = 'PUT';
     }
 
-    $.post(route, {
-        id: $(this).data('note_id'),
-        user_id: self.app.user.id,
-        authenticity_token: self.authToken
-      }, function(data) {
+    $.ajax({
+      url: '/notes/' + $(this).data('note_id') + '/stars/' + self.app.user.id,
+      type: type,
+      success: function(data) {
         // TODO: error ?
       }
-    );
+    });
   });
 
   // Album button click

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -100,6 +100,7 @@ mapkeep.FormManager.prototype.hiddenInput = function(name, value) {
  * @returns {string}
  */
 mapkeep.FormManager.prototype.albumIdString = function(albums) {
+  return '';
   return albums.reduce(function(prev, cur) {
     return prev + cur.id + ',';
   }, '');
@@ -117,8 +118,8 @@ mapkeep.FormManager.prototype.createNoteView =
     var holder = nonUser ? $('<div/>') : $('<form/>');
     holder
       .attr('id', 'noteView')
-      .append(this.createTextGroup(note))
-      .append(this.createAlbumHtml(note));
+      .append(this.createTextGroup(note));
+      //.append(this.createAlbumHtml(note));
 
     if (!nonUser) {
       // add form attributes and hidden inputs

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -60,14 +60,28 @@ mapkeep.FormManager.prototype.init = function(albums) {
   });
 
   // Star button click
+  var self = this;
   overlay.on('click', '#star', function() {
-    // if was empty, add { star - userid, noteid }
-    // if was full, delete star
-    // update star count ?
+    var route;
+    if ($(this).html() === '★') {
+      $(this).html('☆');
+      route = '/notes/delete_star';
+    } else {
+      $(this).html('★');
+      route = '/notes/add_star';
+    }
+
+    $.post(route, {
+        id: $(this).data('note_id'),
+        user_id: self.app.user.id,
+        authenticity_token: self.authToken
+      }, function(data) {
+        // TODO: error ?
+      }
+    );
   });
 
   // Album button click
-  var self = this;
   overlay.on('click', '#album-dropdown a', function() {
     self.albumPrepend($(this).attr('value'));
   });
@@ -137,8 +151,11 @@ mapkeep.FormManager.prototype.createNoteView =
         .append(this.createRadioGroup(note))
         .append(this.createFormButtons(note ? true : false))
         .append(this.hiddenInput('_method', note ? 'patch' : 'post'));
-    } else {
-      holder.find('.group').append('<span id="star">☆</span>');
+    } else if (note) {
+      var star = note.starred ? '★' : '☆';
+      var span = $('<span id="star">' + star + '</span>');
+      span.data('note_id', note.id);
+      holder.find('.group').append(span);
     }
 
     if (note) {

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -62,14 +62,17 @@ mapkeep.FormManager.prototype.init = function(albums) {
   // Star button click
   var self = this;
   overlay.on('click', '#star', function() {
-    var putStar = $(this).html() === '☆';
-    $(this).html(putStar ? '★' : '☆');
-    var noteId = $(this).parent().attr('id');
+    var span = $(this);
+    var putStar = span.html() === '☆';
+    var noteId = span.parent().attr('id');
     $.ajax({
       url: '/notes/' + noteId + '/stars/' + self.app.user.id,
       type: putStar ? 'PUT' : 'DELETE',
-      success: function(data) {
-        // TODO: error ?
+      success: function() {
+        span.html(putStar ? '★' : '☆');
+      },
+      error: function() {
+        self.app.tryAgain();
       }
     });
   });

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -7,11 +7,6 @@ var mapkeep = mapkeep || {};
  * @constructor
  */
 mapkeep.FormManager = function(app, auth) {
-  /** Counter for form identification */
-  this.formNum = 0;
-  /** All forms and views created so far */
-  this.forms = {};
-  this.views = {};
   /** List of all user's albums */
   this.albums = {};
   /** Current opened form */
@@ -100,7 +95,6 @@ mapkeep.FormManager.prototype.hiddenInput = function(name, value) {
  * @returns {string}
  */
 mapkeep.FormManager.prototype.albumIdString = function(albums) {
-  return '';
   return albums.reduce(function(prev, cur) {
     return prev + cur.id + ',';
   }, '');
@@ -108,18 +102,17 @@ mapkeep.FormManager.prototype.albumIdString = function(albums) {
 
 /**
  * Creates a form for a note that is tied to a marker
- * @param marker The note belongs to for coordinates
  * @param note Note to use title and body for if existing
  * @param nonUser Only show the note, no editable features
  * @returns {Number} identifier for form
  */
 mapkeep.FormManager.prototype.createNoteView =
-  function(marker, note, nonUser) {
+  function(note, nonUser) {
     var holder = nonUser ? $('<div/>') : $('<form/>');
     holder
       .attr('id', 'noteView')
-      .append(this.createTextGroup(note));
-      //.append(this.createAlbumHtml(note));
+      .append(this.createTextGroup(note))
+      .append(this.createAlbumHtml(note));
 
     if (!nonUser) {
       // add form attributes and hidden inputs
@@ -129,10 +122,9 @@ mapkeep.FormManager.prototype.createNoteView =
         .attr('method', 'post')
         .attr('data-remote', 'true')
         .attr('accept-charset', 'UTF-8')
-        .append(this.hiddenInput('note[latitude]', marker.position.lat()))
-        .append(this.hiddenInput('note[longitude]', marker.position.lng()))
+        .append(this.hiddenInput('note[latitude]', ''))
+        .append(this.hiddenInput('note[longitude]', ''))
         .append(this.hiddenInput('authenticity_token', this.authToken))
-        .append(this.hiddenInput('form_id', this.formNum))
         .append(this.hiddenInput('note[album_ids][]',
           note ? this.albumIdString(note.albums) : ''))
         .append(this.createRadioGroup(note))
@@ -144,16 +136,7 @@ mapkeep.FormManager.prototype.createNoteView =
       holder.find('input, textarea').attr('readonly', 'readonly');
     }
 
-    // Save marker and form for deletion / manipulation
-    this.app.markers[this.formNum] = marker;
-    if (nonUser) {
-      this.views[this.formNum] = holder;
-    } else {
-      this.forms[this.formNum] = holder;
-    }
-
-    this.app.addMarkerListener(this.formNum);
-    return this.formNum++;
+    return holder;
   };
 
 /**
@@ -391,19 +374,28 @@ mapkeep.FormManager.prototype.resetForm = function() {
 
 /**
  * Close last form and open new one as well as info window with title
- * @param formNum Form identifier
+ * @param note
  * @param timeout For info window open
  */
-mapkeep.FormManager.prototype.showForm = function(formNum, timeout) {
+mapkeep.FormManager.prototype.showForm = function(note, timeout) {
   var overlay = $('#overlay');
-  var nonUser = this.forms[formNum] ? false : true;
-  this.curForm = nonUser ? this.views[formNum] : this.forms[formNum];
+
+  // Create note view if we haven't yet
+  if (note && !note.view) {
+    note.view = this.createNoteView(note, note.user_id != this.app.user.id);
+    this.curForm = note.view;
+  } else if (!note) {
+    // This is a new note
+    this.curForm = this.createNoteView(null, false);
+  } else {
+    this.curForm = note.view;
+  }
 
   // Open info window for note title at corresponding marker after timeout
   setTimeout(function() {
     this.app.openInfoWindow(
       this.curForm.find('input[name=note\\[title\\]]').val(),
-      this.app.markers[formNum]
+      this.app.curMarker // TODO: index marker by note id ?
     );
   }.bind(this), timeout);
 
@@ -411,10 +403,11 @@ mapkeep.FormManager.prototype.showForm = function(formNum, timeout) {
   overlay.find('#noteView').remove();
   overlay.append(this.curForm).removeClass('hide');
 
-  if (!this.curForm.hasClass('new_note') && !nonUser) {
+  var hasForm = overlay.find('form').length > 0;
+  if (!this.curForm.hasClass('new_note') && hasForm) {
     // Force form to be readonly if not a new note
     this.makeReadonly();
-  } else if (!nonUser) {
+  } else if (hasForm) {
     // Hide delete button if it is a new note
     this.makeEditable();
     this.curForm.find('#delete-button').addClass('hide').removeClass('button');
@@ -432,7 +425,10 @@ mapkeep.FormManager.prototype.albumPrepend = function(albumId) {
   var group = this.curForm.find('span[value=' + albumId + ']');
   if (!group.length) {
     // Append label if it doesn't exist and is not hidden
-    $('#album-button').before(this.makeLabelGroup(albumId, true));
+    $('#album-button').before(this.makeLabelGroup({
+      id: albumId,
+      title: this.albums[albumId]
+    }, true));
   } else {
     // Otherwise just unhide the label
     group.removeClass('hide');
@@ -451,8 +447,7 @@ mapkeep.FormManager.prototype.createAlbumHtml = function(note) {
   // Add label groups for albums the note belongs in currently
   if (note && note.albums.length > 0) {
     for (var i = 0; i < note.albums.length; i++) {
-      var albumId = note.albums[i].id;
-      albumHtml.append(this.makeLabelGroup(albumId));
+      albumHtml.append(this.makeLabelGroup(note.albums[i]));
     }
   }
 
@@ -522,14 +517,14 @@ mapkeep.FormManager.prototype.removeAlbumLabels = function() {
  * Creates a label group:
  *    - the album name label (tagged with album id as value)
  *    - a delete X alert label
- * @param albumId For title and id
+ * @param album
  * @param showDelete Whether or not to show the delete button
  * @returns {*|jQuery}
  */
-mapkeep.FormManager.prototype.makeLabelGroup = function(albumId, showDelete) {
+mapkeep.FormManager.prototype.makeLabelGroup = function(album, showDelete) {
   var label = $('<span/>')
     .addClass('label')
-    .html(this.albums[albumId]);
+    .html(album.title);
 
   // Hide label on delete, remove on save
   var deleteLabel = $('<span/>').addClass('alert').html('X');
@@ -548,7 +543,7 @@ mapkeep.FormManager.prototype.makeLabelGroup = function(albumId, showDelete) {
     .addClass('group')
     .append(label)
     .append(deleteLabel)
-    .attr('value', albumId);
+    .attr('value', album.id);
 };
 
 /**

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -122,8 +122,8 @@ mapkeep.FormManager.prototype.createNoteView =
         .attr('method', 'post')
         .attr('data-remote', 'true')
         .attr('accept-charset', 'UTF-8')
-        .append(this.hiddenInput('note[latitude]', ''))
-        .append(this.hiddenInput('note[longitude]', ''))
+        .append(this.hiddenInput('note[latitude]', note.latitude))
+        .append(this.hiddenInput('note[longitude]', note.longitude))
         .append(this.hiddenInput('authenticity_token', this.authToken))
         .append(this.hiddenInput('note[album_ids][]',
           note ? this.albumIdString(note.albums) : ''))

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -147,7 +147,7 @@ mapkeep.FormManager.prototype.createNoteView =
       var star = note.starred ? '★' : '☆';
       var span = $('<span id="star">' + star + '</span>');
       span.data('note_id', note.id);
-      holder.find('.group').append(span);
+      holder.find('#album-div').append(span);
     }
 
     if (note) {
@@ -460,7 +460,7 @@ mapkeep.FormManager.prototype.albumPrepend = function(albumId) {
  * @returns {*|jQuery}
  */
 mapkeep.FormManager.prototype.createAlbumHtml = function(note) {
-  var albumHtml = $('<div/>');
+  var albumHtml = $('<div/>').attr('id', 'album-div');
 
   // Add label groups for albums the note belongs in currently
   if (note && note.albums.length > 0) {

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -129,8 +129,8 @@ mapkeep.FormManager.prototype.createNoteView =
         .attr('method', 'post')
         .attr('data-remote', 'true')
         .attr('accept-charset', 'UTF-8')
-        .append(this.hiddenInput('note[latitude]', note.latitude))
-        .append(this.hiddenInput('note[longitude]', note.longitude))
+        .append(this.hiddenInput('note[latitude]', note ? note.latitude : ''))
+        .append(this.hiddenInput('note[longitude]', note ? note.longitude : ''))
         .append(this.hiddenInput('authenticity_token', this.authToken))
         .append(this.hiddenInput('note[album_ids][]',
           note ? this.albumIdString(note.albums) : ''))

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -62,18 +62,11 @@ mapkeep.FormManager.prototype.init = function(albums) {
   // Star button click
   var self = this;
   overlay.on('click', '#star', function() {
-    var type;
-    if ($(this).html() === '★') {
-      $(this).html('☆');
-      type = 'DELETE';
-    } else {
-      $(this).html('★');
-      type = 'PUT';
-    }
-
+    var putStar = $(this).html() === '☆';
+    $(this).html(putStar ? '★' : '☆');
     $.ajax({
       url: '/notes/' + $(this).data('note_id') + '/stars/' + self.app.user.id,
-      type: type,
+      type: putStar ? 'PUT' : 'DELETE',
       success: function(data) {
         // TODO: error ?
       }

--- a/app/assets/javascripts/geolocation/FormManager.js
+++ b/app/assets/javascripts/geolocation/FormManager.js
@@ -61,7 +61,9 @@ mapkeep.FormManager.prototype.init = function(albums) {
 
   // Star button click
   overlay.on('click', '#star', function() {
-
+    // if was empty, add { star - userid, noteid }
+    // if was full, delete star
+    // update star count ?
   });
 
   // Album button click

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -75,6 +75,12 @@
     .alert, .secondary {
       cursor: pointer;
     }
+
+    #star {
+      cursor: pointer;
+      float: right;
+      font-size: 1.2em;
+    }
   }
 
   #sidebar {

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -2,18 +2,12 @@ class IndexController < ApplicationController
   include Geokit::Geocoders
 
   def index
-    # TODO: find by proximity to location as well
-    user_notes = current_user.nil? ? [] : current_user.notes
-    public_notes = Note.where(private: false)
-                       .where.not(user_id: current_user.id)
-                       .all
-
-    @notes = { :user_notes => user_notes, :public_notes => public_notes }
-
     if request.remote_ip == '127.0.0.1'
       @location = MultiGeocoder.geocode('75.82.170.180')
     else
       @location = MultiGeocoder.geocode(request.remote_ip)
     end
+
+    @notes = Note.find_by_proximity(@location, 1, current_user)
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -46,9 +46,24 @@ class NotesController < ApplicationController
     user_id = params[:user_id]
     note = Note.find(note_id)
     respond_to do |format|
-      # TODO: prevent duplicate records
+      # TODO: prevent duplicate records, is note.stars needed?
       if note.stars.create!(note_id: note_id, user_id: user_id)
         note.star_count = note.star_count + 1
+        note.save
+        format.json { render json: params, status: :ok }
+      else
+        format.json { render json: params, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def delete_star
+    note_id = params[:id]
+    user_id = params[:user_id]
+    note = Note.find(note_id)
+    respond_to do |format|
+      if note.stars.where(user_id: user_id).destroy_all # TODO: ensure doesn't delete more
+        note.star_count = note.star_count - 1
         note.save
         format.json { render json: params, status: :ok }
       else

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -40,6 +40,19 @@ class NotesController < ApplicationController
     end
   end
 
+  # POST /notes/add_star
+  def add_star
+    note_id = params[:id]
+    user_id = params[:user_id]
+    respond_to do |format|
+      note = Note.find(note_id)
+      note.stars.create(note_id: note_id, user_id: user_id)
+      note.star_count = note.star_count + 1
+      note.save
+      format.json { render json: params, status: :ok }
+    end
+  end
+
   # PATCH/PUT /notes/1
   # PATCH/PUT /notes/1.json
   def update

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -44,12 +44,16 @@ class NotesController < ApplicationController
   def add_star
     note_id = params[:id]
     user_id = params[:user_id]
+    note = Note.find(note_id)
     respond_to do |format|
-      note = Note.find(note_id)
-      note.stars.create(note_id: note_id, user_id: user_id)
-      note.star_count = note.star_count + 1
-      note.save
-      format.json { render json: params, status: :ok }
+      # TODO: prevent duplicate records
+      if note.stars.create!(note_id: note_id, user_id: user_id)
+        note.star_count = note.star_count + 1
+        note.save
+        format.json { render json: params, status: :ok }
+      else
+        format.json { render json: params, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -40,14 +40,13 @@ class NotesController < ApplicationController
     end
   end
 
-  # POST /notes/add_star
+  # PUT /notes/stars
   def add_star
     note_id = params[:id]
-    user_id = params[:user_id]
     note = Note.find(note_id)
     respond_to do |format|
       # TODO: prevent duplicate records, is note.stars needed?
-      if note.stars.create!(note_id: note_id, user_id: user_id)
+      if note.stars.create!(note_id: note_id, user_id: params[:user_id])
         note.star_count = note.star_count + 1
         note.save
         format.json { render json: params, status: :ok }
@@ -57,12 +56,11 @@ class NotesController < ApplicationController
     end
   end
 
+  # DELETE /notes/stars
   def delete_star
-    note_id = params[:id]
-    user_id = params[:user_id]
-    note = Note.find(note_id)
+    note = Note.find(params[:id])
     respond_to do |format|
-      if note.stars.where(user_id: user_id).destroy_all # TODO: ensure doesn't delete more
+      if note.stars.where(user_id: params[:user_id]).destroy_all # TODO: ensure doesn't delete more
         note.star_count = note.star_count - 1
         note.save
         format.json { render json: params, status: :ok }

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -59,7 +59,7 @@ class NotesController < ApplicationController
   def delete_star
     note = Note.find(params[:id])
     respond_to do |format|
-      if note.stars.where(user_id: params[:user_id]).destroy_all # TODO: ensure doesn't delete more
+      if note.stars.where(user_id: params[:user_id]).destroy_all
         note.star_count = note.star_count - 1
         note.save
         format.json { render json: params, status: :ok }

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -45,7 +45,6 @@ class NotesController < ApplicationController
     note_id = params[:id]
     note = Note.find(note_id)
     respond_to do |format|
-      # TODO: prevent duplicate records, is note.stars needed?
       if note.stars.create!(note_id: note_id, user_id: params[:user_id])
         note.star_count = note.star_count + 1
         note.save

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,8 +2,13 @@ class Note < ActiveRecord::Base
   belongs_to :user
   has_many :collections, :dependent => :destroy
   has_many :albums, :through => :collections
+
+  has_many :stars, :dependent => :destroy
+  has_many :users, :through => :stars
+
   before_save :set_point
   before_update :set_point
+
   validates :title, :body, :user_id, presence: true
   validates :latitude, :longitude, :user_id, numericality: true
 
@@ -23,7 +28,7 @@ class Note < ActiveRecord::Base
   def Note.find_by_proximity(location, degree, current_user)
     linestring_text = get_linestring_text(location, degree)
     Note.find_by_sql("
-            SELECT *
+            SELECT id, latitude, longitude, user_id
             FROM notes
             FORCE INDEX (index_notes_on_latlon)
             WHERE

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -30,6 +30,7 @@ class Note < ActiveRecord::Base
               ((private=false AND user_id!=#{current_user.id}) OR
               user_id=#{current_user.id}) AND
               MBRContains(GeomFromText( '#{linestring_text}' ), notes.latlon)")
+    # sort by data & star count
   end
 
   # Gets text representation of linestring centered around location

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -4,34 +4,35 @@ class Note < ActiveRecord::Base
   has_many :albums, :through => :collections
   before_save :set_point
   before_update :set_point
+  validates :title, :body, :user_id, presence: true
+  validates :latitude, :longitude, :user_id, numericality: true
 
-  # By default, use the GEOS implementation for spatial columns.
+  # By default, use the GEOS implementation for spatial columns
   self.rgeo_factory_generator = RGeo::Geos.method(:factory)
 
   # But use a geographic implementation for the :latlon column.
   set_rgeo_factory_for_column(:latlon, RGeo::Geographic.spherical_factory)
 
-  validates :title, :body, :user_id, presence: true
-  validates :latitude, :longitude, :user_id, numericality: true
-
+  # Uses lat and lng to create and set point within note
   def set_point
     self[:latlon] = RGeo::Geographic.spherical_factory(:srid => 4326)
                         .point(self[:longitude], self[:latitude])
   end
 
-  # Finds all public and user's notes close to location to degree
+  # Finds all public and user's notes close to location to certain degree
   def Note.find_by_proximity(location, degree, current_user)
     linestring_text = get_linestring_text(location, degree)
     Note.find_by_sql("
             SELECT *
             FROM notes
+            FORCE INDEX (index_notes_on_latlon)
             WHERE
               ((private=false AND user_id!=#{current_user.id}) OR
               user_id=#{current_user.id}) AND
               MBRContains(GeomFromText( '#{linestring_text}' ), notes.latlon)")
   end
 
-  # Gets text representation of linestring centered around user location
+  # Gets text representation of linestring centered around location
   def Note.get_linestring_text(location, degree)
     "LINESTRING(#{location.lng - degree} #{location.lat - degree},
                 #{location.lng + degree} #{location.lat + degree})"

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -20,8 +20,10 @@ class Note < ActiveRecord::Base
 
   # Uses lat and lng to create and set point within note
   def set_point
-    self[:latlon] = RGeo::Geographic.spherical_factory(:srid => 4326)
-                        .point(self[:longitude], self[:latitude])
+    if self.latitude_was != self.latitude || self.longitude_was != self.longitude
+      self[:latlon] = RGeo::Geographic.spherical_factory(:srid => 4326)
+                          .point(self[:longitude], self[:latitude])
+    end
   end
 
   # Finds all public and user's notes close to location to certain degree

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -18,4 +18,22 @@ class Note < ActiveRecord::Base
     self[:latlon] = RGeo::Geographic.spherical_factory(:srid => 4326)
                         .point(self[:longitude], self[:latitude])
   end
+
+  # Finds all public and user's notes close to location to degree
+  def Note.find_by_proximity(location, degree, current_user)
+    linestring_text = get_linestring_text(location, degree)
+    Note.find_by_sql("
+            SELECT *
+            FROM notes
+            WHERE
+              ((private=false AND user_id!=#{current_user.id}) OR
+              user_id=#{current_user.id}) AND
+              MBRContains(GeomFromText( '#{linestring_text}' ), notes.latlon)")
+  end
+
+  # Gets text representation of linestring centered around user location
+  def Note.get_linestring_text(location, degree)
+    "LINESTRING(#{location.lng - degree} #{location.lat - degree},
+                #{location.lng + degree} #{location.lat + degree})"
+  end
 end

--- a/app/models/star.rb
+++ b/app/models/star.rb
@@ -1,0 +1,4 @@
+class Star < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :note
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,7 @@ class User < ActiveRecord::Base
 
   has_many :notes, dependent: :destroy
   has_many :albums, dependent: :destroy
+
+  has_many :starred_notes, :through => :stars, :source => :notes
+  has_many :stars, :dependent => :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,6 @@ class User < ActiveRecord::Base
   has_many :notes, dependent: :destroy
   has_many :albums, dependent: :destroy
 
-  has_many :starred_notes, :through => :stars, :source => :notes
+  has_many :starred_notes, :through => :stars, :source => :note
   has_many :stars, :dependent => :destroy
 end

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -9,10 +9,13 @@
   var app = new mapkeep.App('<%= session[:_csrf_token] %>');
   google.maps.event.addDomListener(window, 'load', function() {
     app.init(
-      { lat: '<%= @location.lat %>', lng: '<%= @location.lng %>' },
+      {
+        location: { lat: '<%= @location.lat %>', lng: '<%= @location.lng %>' },
+        id: <%= current_user.id %>
+      },
       <%= raw @notes.to_json(
                   :include => { :albums => { :only => :id }},
-                  :except => [:user_id, :latlon]) %>,
+                  :except => [:latlon]) %>,
       <%= raw current_user.albums.to_json(:only => [:title, :id]) %>);
   });
 <% end %>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -13,9 +13,7 @@
         location: { lat: '<%= @location.lat %>', lng: '<%= @location.lng %>' },
         id: <%= current_user.id %>
       },
-      <%= raw @notes.to_json(
-                  :include => { :albums => { :only => :id }},
-                  :except => [:latlon]) %>,
+      <%= raw @notes.to_json(:only => [:latitude, :longitude, :id, :user_id]) %>,
       <%= raw current_user.albums.to_json(:only => [:title, :id]) %>);
   });
 <% end %>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -13,7 +13,7 @@
         location: { lat: '<%= @location.lat %>', lng: '<%= @location.lng %>' },
         id: <%= current_user.id %>
       },
-      <%= raw @notes.to_json(:only => [:latitude, :longitude, :id, :user_id]) %>,
+      <%= raw @notes.to_json %>,
       <%= raw current_user.albums.to_json(:only => [:title, :id]) %>);
   });
 <% end %>

--- a/app/views/notes/show.json.jbuilder
+++ b/app/views/notes/show.json.jbuilder
@@ -1,2 +1,3 @@
 json.extract! @note, :id, :title, :body, :user_id, :latitude, :longitude
 json.albums @note.albums, :id, :title
+json.starred current_user.starred_notes.where(:id => @note.id).present?

--- a/app/views/notes/show.json.jbuilder
+++ b/app/views/notes/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.extract! @note, :id, :title, :body, :user_id, :latitude, :longitude
-json.albums @note.albums, :id, :title
+json.albums @note.albums.select([ :id, :title ])
 json.starred current_user.starred_notes.exists?(:id => @note.id)

--- a/app/views/notes/show.json.jbuilder
+++ b/app/views/notes/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.extract! @note, :id, :title, :body, :user_id, :latitude, :longitude
 json.albums @note.albums, :id, :title
-json.starred current_user.starred_notes.where(:id => @note.id).present?
+json.starred current_user.starred_notes.exists?(:id => @note.id)

--- a/app/views/notes/show.json.jbuilder
+++ b/app/views/notes/show.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! @note, :id, :title, :body, :created_at, :updated_at
+json.extract! @note, :id, :title, :body, :user_id
 json.albums @note.albums, :id, :title

--- a/app/views/notes/show.json.jbuilder
+++ b/app/views/notes/show.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! @note, :id, :title, :body, :user_id
+json.extract! @note, :id, :title, :body, :user_id, :latitude, :longitude
 json.albums @note.albums, :id, :title

--- a/app/views/notes/show.json.jbuilder
+++ b/app/views/notes/show.json.jbuilder
@@ -1,1 +1,2 @@
-json.extract! @note, :id, :created_at, :updated_at
+json.extract! @note, :id, :title, :body, :created_at, :updated_at
+json.albums @note.albums, :id, :title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  resources :albums
   devise_for :users
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
   resources :notes
+  resources :albums
 
   # Example resource route (maps HTTP verbs to controller actions automatically):
   #   resources :products

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
 
+  # TODO: Be restful
   post 'notes/add_star' => 'notes#add_star'
+  post 'notes/delete_star' => 'notes#delete_star'
 
   resources :notes
   resources :albums

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,8 @@ Rails.application.routes.draw do
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
 
-  # TODO: Be restful
-  post 'notes/add_star' => 'notes#add_star'
-  post 'notes/delete_star' => 'notes#delete_star'
+  put 'notes/:id/stars/:user_id' => 'notes#add_star'
+  delete 'notes/:id/stars/:user_id' => 'notes#delete_star'
 
   resources :notes
   resources :albums

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
 
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
+
+  post 'notes/add_star' => 'notes#add_star'
+
   resources :notes
   resources :albums
 

--- a/db/migrate/20150509232035_add_star_count_to_notes.rb
+++ b/db/migrate/20150509232035_add_star_count_to_notes.rb
@@ -1,0 +1,5 @@
+class AddStarCountToNotes < ActiveRecord::Migration
+  def change
+    add_column :notes, :star_count, :integer, :default => 0
+  end
+end

--- a/db/migrate/20150509235824_add_stars.rb
+++ b/db/migrate/20150509235824_add_stars.rb
@@ -6,6 +6,8 @@ class AddStars < ActiveRecord::Migration
 
       t.timestamps
     end
+
+    add_index  :stars, [:note_id, :user_id], :unique => true
   end
 
   def self.down

--- a/db/migrate/20150509235824_add_stars.rb
+++ b/db/migrate/20150509235824_add_stars.rb
@@ -1,0 +1,14 @@
+class AddStars < ActiveRecord::Migration
+  def self.up
+    create_table :stars do |t|
+      t.integer :user_id
+      t.integer :note_id
+
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :stars
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -32,7 +32,7 @@ CREATE TABLE `albums` (
   PRIMARY KEY (`id`),
   KEY `index_albums_on_user_id` (`user_id`),
   CONSTRAINT `fk_rails_964016e0e8` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -48,8 +48,11 @@ CREATE TABLE `collections` (
   `note_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=62 DEFAULT CHARSET=utf8;
+  `user_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_collections_on_user_id` (`user_id`),
+  CONSTRAINT `fk_rails_9b33697360` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -83,10 +86,11 @@ CREATE TABLE `notes` (
   `updated_at` datetime NOT NULL,
   `user_id` int(11) DEFAULT NULL,
   `private` tinyint(1) DEFAULT '1',
+  `star_count` int(11) DEFAULT '0',
   PRIMARY KEY (`id`),
   SPATIAL KEY `index_notes_on_latlon` (`latlon`),
   KEY `index_notes_on_user_id` (`user_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=20 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM AUTO_INCREMENT=100009 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50003 SET @saved_cs_client      = @@character_set_client */ ;
 /*!50003 SET @saved_cs_results     = @@character_set_results */ ;
@@ -149,7 +153,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -161,7 +165,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-05-04 11:50:10
+-- Dump completed on 2015-05-09 16:22:39
 INSERT INTO schema_migrations (version) VALUES ('20150412000202');
 
 INSERT INTO schema_migrations (version) VALUES ('20150413214220');
@@ -187,4 +191,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150427002956');
 INSERT INTO schema_migrations (version) VALUES ('20150428002956');
 
 INSERT INTO schema_migrations (version) VALUES ('20150504184918');
+
+INSERT INTO schema_migrations (version) VALUES ('20150507202906');
+
+INSERT INTO schema_migrations (version) VALUES ('20150509232035');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -32,7 +32,7 @@ CREATE TABLE `albums` (
   PRIMARY KEY (`id`),
   KEY `index_albums_on_user_id` (`user_id`),
   CONSTRAINT `fk_rails_964016e0e8` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=19 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -52,7 +52,7 @@ CREATE TABLE `collections` (
   PRIMARY KEY (`id`),
   KEY `index_collections_on_user_id` (`user_id`),
   CONSTRAINT `fk_rails_9b33697360` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=68 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -90,7 +90,7 @@ CREATE TABLE `notes` (
   PRIMARY KEY (`id`),
   SPATIAL KEY `index_notes_on_latlon` (`latlon`),
   KEY `index_notes_on_user_id` (`user_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=100009 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50003 SET @saved_cs_client      = @@character_set_client */ ;
 /*!50003 SET @saved_cs_results     = @@character_set_results */ ;
@@ -130,6 +130,23 @@ CREATE TABLE `schema_migrations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `stars`
+--
+
+DROP TABLE IF EXISTS `stars`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `stars` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `note_id` int(11) DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `users`
 --
 
@@ -153,7 +170,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -165,7 +182,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-05-09 16:22:39
+-- Dump completed on 2015-05-09 16:59:54
 INSERT INTO schema_migrations (version) VALUES ('20150412000202');
 
 INSERT INTO schema_migrations (version) VALUES ('20150413214220');
@@ -195,4 +212,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150504184918');
 INSERT INTO schema_migrations (version) VALUES ('20150507202906');
 
 INSERT INTO schema_migrations (version) VALUES ('20150509232035');
+
+INSERT INTO schema_migrations (version) VALUES ('20150509235824');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -90,7 +90,7 @@ CREATE TABLE `notes` (
   PRIMARY KEY (`id`),
   SPATIAL KEY `index_notes_on_latlon` (`latlon`),
   KEY `index_notes_on_user_id` (`user_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50003 SET @saved_cs_client      = @@character_set_client */ ;
 /*!50003 SET @saved_cs_results     = @@character_set_results */ ;
@@ -142,7 +142,8 @@ CREATE TABLE `stars` (
   `note_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_stars_on_note_id_and_user_id` (`note_id`,`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -182,7 +183,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-05-09 16:59:54
+-- Dump completed on 2015-05-11 17:36:20
 INSERT INTO schema_migrations (version) VALUES ('20150412000202');
 
 INSERT INTO schema_migrations (version) VALUES ('20150413214220');
@@ -214,4 +215,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150507202906');
 INSERT INTO schema_migrations (version) VALUES ('20150509232035');
 
 INSERT INTO schema_migrations (version) VALUES ('20150509235824');
+
+INSERT INTO schema_migrations (version) VALUES ('20150512003036');
 


### PR DESCRIPTION
This pull request does the following:

Use ajax requests to get note information when user requests it (including the pesky album inner join)

Add ability to star public notes
- Stars table of user id's and note id's
- Star count to notes for use below

Returned notes are split into two queries:
- All user notes within MBR (minimum bounding rectangle) around user location
- Public notes within MBR ordered first by day created, then star count

Still needed: dynamic bounding box so when user changes zoom level or moves the map, new content is loaded
