### PR TITLE
Modify notes listing caching behavior

### DIFF
--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -6,7 +6,6 @@
 });
 </script>
 
-<% cache(cache_key_for_notes) do %>
 
   <h1>Listing Notes</h1>
   <% unless @notes.empty? %>
@@ -20,8 +19,8 @@
       </thead>
 
       <tbody>
+      <% cache do %>
       <% @notes.each do |note| %>
-        <% cache(note) do %>
           <tr>
             <td><%= note.title %></td>
             <td><%= link_to 'Show', note %></td>
@@ -40,7 +39,6 @@
     <br>
   <% end %>
 
-<% end %>
 
 <br>
 


### PR DESCRIPTION
Modify caching behavior of notes listing page, which will now only cache the results of the notes titles and such. The application was caching all the partial renderings of the note pages, which was slow and inefficient server-side.
